### PR TITLE
Paddle::Object#update Method

### DIFF
--- a/lib/paddle/object.rb
+++ b/lib/paddle/object.rb
@@ -15,5 +15,26 @@ module Paddle
         obj
       end
     end
+
+    def update(**params)
+      method_missing :update unless klass.respond_to? :update
+
+      primary_attributes = klass.method(:update).parameters.select { |(type, name)| type == :keyreq }.map(&:last) # Identified by whatever is a required named parameter.
+
+      primary_attributes.each do |attrib|
+        # ? Should we need to handle blank strings here?
+        params[attrib] = self[attrib] || self["#{attrib}_id"] # Handling for customer (customer_id) and id.
+      end
+
+      klass.public_send(:update, **params).each_pair { |key, val| self[key] = val } # Updating self
+
+      self
+    end
+
+    private
+
+    def klass
+      self.class
+    end
   end
 end

--- a/test/paddle/models/address_test.rb
+++ b/test/paddle/models/address_test.rb
@@ -44,4 +44,19 @@ class AddressTest < Minitest::Test
       end
     end
   end
+
+  def test_object_update_with_ids
+    VCR.use_cassette("test_address_retrieve") do
+      Paddle::Address.retrieve(customer: "ctm_01h7dtf1yg8jge7980baqdkjk8", id: "add_01h7dtvh64g9c20asb65dc411r").tap do |address|
+        VCR.use_cassette("test_address_update") do
+          address.update(description: "Downing Street", customer: "lmao", id: "lmao")
+        end
+
+        assert_equal Paddle::Address, address.class
+        assert_equal "Downing Street", address.description
+        refute_equal "lmao", address.id
+        refute_equal "lmao", address.customer_id
+      end
+    end
+  end
 end

--- a/test/paddle/models/address_test.rb
+++ b/test/paddle/models/address_test.rb
@@ -10,10 +10,10 @@ class AddressTest < Minitest::Test
   end
 
   def test_address_retrieve
-    address = Paddle::Address.retrieve(customer: "ctm_01h7dtf1yg8jge7980baqdkjk8", id: "add_01h7dtpj3a5ygxw13fzhw8h445")
+    address = Paddle::Address.retrieve(customer: "ctm_01h7dtf1yg8jge7980baqdkjk8", id: "add_01h7dtvh64g9c20asb65dc411r")
 
     assert_equal Paddle::Address, address.class
-    assert_equal "add_01h7dtpj3a5ygxw13fzhw8h445", address.id
+    assert_equal "add_01h7dtvh64g9c20asb65dc411r", address.id
     assert_equal "124 City Road", address.first_line
   end
 
@@ -30,5 +30,18 @@ class AddressTest < Minitest::Test
 
     assert_equal Paddle::Address, address.class
     assert_equal "Downing Street", address.description
+  end
+
+  def test_object_update_without_ids
+    VCR.use_cassette("test_address_retrieve") do
+      Paddle::Address.retrieve(customer: "ctm_01h7dtf1yg8jge7980baqdkjk8", id: "add_01h7dtvh64g9c20asb65dc411r").tap do |address|
+        VCR.use_cassette("test_address_update") do
+          address.update(description: "Downing Street")
+        end
+
+        assert_equal Paddle::Address, address.class
+        assert_equal "Downing Street", address.description
+      end
+    end
   end
 end

--- a/test/paddle/models/business_test.rb
+++ b/test/paddle/models/business_test.rb
@@ -10,10 +10,10 @@ class BusinessTest < Minitest::Test
   end
 
   def test_business_retrieve
-    business = Paddle::Business.retrieve(customer: "ctm_01h7dtf1yg8jge7980baqdkjk8", id: "biz_01h7dv63eze6r79924ch5c1rbd")
+    business = Paddle::Business.retrieve(customer: "ctm_01h7dtf1yg8jge7980baqdkjk8", id: "biz_01h7dz69ksn40x5zrvekgh1xrn")
 
     assert_equal Paddle::Business, business.class
-    assert_equal "biz_01h7dv63eze6r79924ch5c1rbd", business.id
+    assert_equal "biz_01h7dz69ksn40x5zrvekgh1xrn", business.id
     assert_equal "My Business", business.name
   end
 
@@ -30,5 +30,33 @@ class BusinessTest < Minitest::Test
 
     assert_equal Paddle::Business, business.class
     assert_equal "123123", business.company_number
+  end
+
+  def test_object_update_without_ids
+    VCR.use_cassette("test_business_retrieve") do
+      Paddle::Business.retrieve(customer: "ctm_01h7dtf1yg8jge7980baqdkjk8", id: "biz_01h7dz69ksn40x5zrvekgh1xrn").tap do |business|
+        VCR.use_cassette("test_business_update") do
+          business.update(company_number: "123123")
+        end
+
+        assert_equal Paddle::Business, business.class
+        assert_equal "123123", business.company_number
+      end
+    end
+  end
+
+  def test_object_update_with_ids
+    VCR.use_cassette("test_business_retrieve") do
+      Paddle::Business.retrieve(customer: "ctm_01h7dtf1yg8jge7980baqdkjk8", id: "biz_01h7dz69ksn40x5zrvekgh1xrn").tap do |business|
+        VCR.use_cassette("test_business_update") do
+          business.update(company_number: "123123", customer: "lmao", id: "lmao")
+        end
+
+        assert_equal Paddle::Business, business.class
+        assert_equal "123123", business.company_number
+        refute_equal "lmao", business.id
+        refute_equal "lmao", business.customer_id
+      end
+    end
   end
 end

--- a/test/paddle/models/customer_test.rb
+++ b/test/paddle/models/customer_test.rb
@@ -10,10 +10,10 @@ class CustomerTest < Minitest::Test
   end
 
   def test_customer_retrieve
-    customer = Paddle::Customer.retrieve(id: "ctm_01h7dtf1yg8jge7980baqdkjk8")
+    customer = Paddle::Customer.retrieve(id: "ctm_01h7dth5z8q7df4r73r4jek70g")
 
     assert_equal Paddle::Customer, customer.class
-    assert_equal "ctm_01h7dtf1yg8jge7980baqdkjk8", customer.id
+    assert_equal "ctm_01h7dth5z8q7df4r73r4jek70g", customer.id
     assert_equal "dean@mycompany.com", customer.email
   end
 
@@ -46,5 +46,32 @@ class CustomerTest < Minitest::Test
     assert_equal Paddle::CreditBalance, credit.class
     assert_equal "USD", credit.currency_code
     assert_equal "0", credit.balance.available
+  end
+
+  def test_object_update_without_ids
+    VCR.use_cassette("test_customer_retrieve") do
+      Paddle::Customer.retrieve(id: "ctm_01h7dth5z8q7df4r73r4jek70g").tap do |customer|
+        VCR.use_cassette("test_customer_update") do
+          customer.update(email: "gob@bluthcompany.com")
+        end
+
+        assert_equal Paddle::Customer, customer.class
+        assert_equal "gob@bluthcompany.com", customer.email
+      end
+    end
+  end
+
+  def test_object_update_with_ids
+    VCR.use_cassette("test_customer_retrieve") do
+      Paddle::Customer.retrieve(id: "ctm_01h7dth5z8q7df4r73r4jek70g").tap do |customer|
+        VCR.use_cassette("test_customer_update") do
+          customer.update(email: "gob@bluthcompany.com", id: "lmao")
+        end
+
+        assert_equal Paddle::Customer, customer.class
+        assert_equal "gob@bluthcompany.com", customer.email
+        refute_equal "lmao", customer.id
+      end
+    end
   end
 end

--- a/test/paddle/models/discount_test.rb
+++ b/test/paddle/models/discount_test.rb
@@ -10,10 +10,10 @@ class DiscountTest < Minitest::Test
   end
 
   def test_discount_retrieve
-    discount = Paddle::Discount.retrieve(id: "dsc_01h7dtzexhveh8sqfm16b0yw4d")
+    discount = Paddle::Discount.retrieve(id: "dsc_01h7dv1243xervzbkfxkg56cnn")
 
     assert_equal Paddle::Discount, discount.class
-    assert_equal "dsc_01h7dtzexhveh8sqfm16b0yw4d", discount.id
+    assert_equal "dsc_01h7dv1243xervzbkfxkg56cnn", discount.id
     assert_equal "10% off", discount.description
   end
 
@@ -30,5 +30,34 @@ class DiscountTest < Minitest::Test
 
     assert_equal Paddle::Discount, discount.class
     assert_equal "WELCOME", discount.code
+  end
+
+  def test_object_update_without_ids
+    VCR.use_cassette("test_discount_retrieve") do
+      Paddle::Discount.retrieve(id: "dsc_01h7dv1243xervzbkfxkg56cnn").tap do |discount|
+        VCR.use_cassette("test_discount_update") do
+          discount.update(code: "WELCOME", enabled_for_checkout: true)
+        end
+
+        assert_equal Paddle::Discount, discount.class
+        assert_equal "WELCOME", discount.code
+        assert discount.enabled_for_checkout
+      end
+    end
+  end
+
+  def test_object_update_with_ids
+    VCR.use_cassette("test_discount_retrieve") do
+      Paddle::Discount.retrieve(id: "dsc_01h7dv1243xervzbkfxkg56cnn").tap do |discount|
+        VCR.use_cassette("test_discount_update") do
+          discount.update(code: "WELCOME", enabled_for_checkout: true, id: "lmao")
+        end
+
+        assert_equal Paddle::Discount, discount.class
+        assert_equal "WELCOME", discount.code
+        assert discount.enabled_for_checkout
+        refute_equal "lmao", discount.id
+      end
+    end
   end
 end

--- a/test/vcr_cassettes/test_address_retrieve.yml
+++ b/test/vcr_cassettes/test_address_retrieve.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://sandbox-api.paddle.com/customers/ctm_01h7dtf1yg8jge7980baqdkjk8/addresses/add_01h7dtpj3a5ygxw13fzhw8h445
+    uri: https://sandbox-api.paddle.com/customers/ctm_01h7dtf1yg8jge7980baqdkjk8/addresses/add_01h7dtvh64g9c20asb65dc411r
     body:
       encoding: US-ASCII
       string: ''
@@ -60,7 +60,7 @@ http_interactions:
       - gzip
     body:
       encoding: ASCII-8BIT
-      string: '{"data":{"id":"add_01h7dtpj3a5ygxw13fzhw8h445","status":"active","description":"Work","first_line":"124
+      string: '{"data":{"id":"add_01h7dtvh64g9c20asb65dc411r","customer_id":"ctm_01h7dtf1yg8jge7980baqdkjk8","status":"active","description":"Work","first_line":"124
         City Road","second_line":"","city":"London","postal_code":"EC1V 2NX","region":"","country_code":"GB","created_at":"2023-08-09T18:59:42.826Z","updated_at":"2023-08-09T18:59:42.826Z"},"meta":{"request_id":"d476060c-efaa-49c9-9221-bad56d5b466a"}}'
   recorded_at: Wed, 09 Aug 2023 19:02:25 GMT
 recorded_with: VCR 6.2.0

--- a/test/vcr_cassettes/test_business_retrieve.yml
+++ b/test/vcr_cassettes/test_business_retrieve.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://sandbox-api.paddle.com/customers/ctm_01h7dtf1yg8jge7980baqdkjk8/businesses/biz_01h7dv63eze6r79924ch5c1rbd
+    uri: https://sandbox-api.paddle.com/customers/ctm_01h7dtf1yg8jge7980baqdkjk8/businesses/biz_01h7dz69ksn40x5zrvekgh1xrn
     body:
       encoding: US-ASCII
       string: ''
@@ -60,7 +60,7 @@ http_interactions:
       - gzip
     body:
       encoding: ASCII-8BIT
-      string: '{"data":{"id":"biz_01h7dv63eze6r79924ch5c1rbd","status":"active","name":"My
+      string: '{"data":{"id":"biz_01h7dz69ksn40x5zrvekgh1xrn", "customer_id": "ctm_01h7dtf1yg8jge7980baqdkjk8", "status":"active","name":"My
         Business","company_number":"123123","tax_identifier":"","contacts":[],"created_at":"2023-08-09T19:08:12.127Z","updated_at":"2023-08-09T19:08:12.127Z"},"meta":{"request_id":"8fe95e26-8c6d-43da-be91-99d4decc1941"}}'
   recorded_at: Wed, 09 Aug 2023 20:17:40 GMT
 recorded_with: VCR 6.2.0

--- a/test/vcr_cassettes/test_customer_retrieve.yml
+++ b/test/vcr_cassettes/test_customer_retrieve.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://sandbox-api.paddle.com/customers/ctm_01h7dtf1yg8jge7980baqdkjk8
+    uri: https://sandbox-api.paddle.com/customers/ctm_01h7dth5z8q7df4r73r4jek70g
     body:
       encoding: US-ASCII
       string: ''
@@ -60,6 +60,6 @@ http_interactions:
       - gzip
     body:
       encoding: ASCII-8BIT
-      string: '{"data":{"id":"ctm_01h7dtf1yg8jge7980baqdkjk8","status":"active","name":"","email":"dean@mycompany.com","marketing_consent":false,"locale":"en","created_at":"2023-08-09T18:55:36.912Z","updated_at":"2023-08-09T18:55:36.912Z"},"meta":{"request_id":"cffc0ee1-a969-49b1-8030-26e8ac1c1c64"}}'
+      string: '{"data":{"id":"ctm_01h7dth5z8q7df4r73r4jek70g","status":"active","name":"","email":"dean@mycompany.com","marketing_consent":false,"locale":"en","created_at":"2023-08-09T18:55:36.912Z","updated_at":"2023-08-09T18:55:36.912Z"},"meta":{"request_id":"cffc0ee1-a969-49b1-8030-26e8ac1c1c64"}}'
   recorded_at: Wed, 09 Aug 2023 18:56:13 GMT
 recorded_with: VCR 6.2.0

--- a/test/vcr_cassettes/test_discount_retrieve.yml
+++ b/test/vcr_cassettes/test_discount_retrieve.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://sandbox-api.paddle.com/discounts/dsc_01h7dtzexhveh8sqfm16b0yw4d
+    uri: https://sandbox-api.paddle.com/discounts/dsc_01h7dv1243xervzbkfxkg56cnn
     body:
       encoding: US-ASCII
       string: ''
@@ -60,7 +60,7 @@ http_interactions:
       - gzip
     body:
       encoding: ASCII-8BIT
-      string: '{"data":{"id":"dsc_01h7dtzexhveh8sqfm16b0yw4d","status":"active","description":"10%
+      string: '{"data":{"id":"dsc_01h7dv1243xervzbkfxkg56cnn","status":"active","description":"10%
         off","enabled_for_checkout":true,"code":"10OFF","type":"percentage","amount":"10","currency_code":null,"recur":false,"maximum_recurring_intervals":null,"usage_limit":null,"restrict_to":null,"expires_at":null,"times_used":0,"created_at":"2023-08-09T19:04:34.481Z","updated_at":"2023-08-09T19:04:34.481Z"},"meta":{"request_id":"5391814e-0014-4f53-924d-b7fed970b820"}}'
   recorded_at: Wed, 09 Aug 2023 19:05:27 GMT
 recorded_with: VCR 6.2.0


### PR DESCRIPTION
## Why?
I was using the gem and figured any Paddle model having an update method would have been a tad bit more helpful in case of readibility and managing the code better.

## How?
Every class that inherits Paddle::Object would have an `update` instance method, if it has a singleton method of the same name.

This helps in writing update calls in a better way

```ruby
# Before

Paddle::Business.retrieve(customer: "some_customerid", id: "some_businessid")
Paddle::Business.update(customer: "some_customerid", id: "some_businessid", name: "Some new name")

# After
Paddle::Business.retrieve(customer: "some_customerid", id: "some_businessid").update(name: "Some new name")
```

## Note
This PR is not yet considered complete from my end as there are test cases I need to finish, and some final polishes in the implementation. These changes would be done only if I get a green signal from the maintainers!