### PR TITLE
Add more detailed error handling

### DIFF
--- a/lib/paddle.rb
+++ b/lib/paddle.rb
@@ -9,6 +9,8 @@ module Paddle
   autoload :Client, "paddle/client"
   autoload :Collection, "paddle/collection"
   autoload :Error, "paddle/error"
+  autoload :ErrorFactory, "paddle/error"
+
   autoload :Object, "paddle/object"
 
   class << self

--- a/lib/paddle/client.rb
+++ b/lib/paddle/client.rb
@@ -34,30 +34,16 @@ module Paddle
 
       def handle_response(response)
         case response.status
-        when 400
-          raise Error, "Error 400: Your request was malformed. '#{response.body["error"]["code"]}'"
-        when 401
-          raise Error, "Error 401: You did not supply valid authentication credentials. '#{response.body["error"]}'"
-        when 403
-          raise Error, "Error 403: You are not allowed to perform that action. '#{response.body["error"]["code"]}'"
-        when 404
-          raise Error, "Error 404: No results were found for your request. '#{response.body["error"]["code"]}'"
-        when 409
-          raise Error, "Error 409: Your request was a conflict. '#{response.body["error"]["code"]}'"
-        when 429
-          raise Error, "Error 429: Your request exceeded the API rate limit. '#{response.body["error"]["code"]}'"
-        when 500
-          raise Error, "Error 500: We were unable to perform the request due to server-side problems. '#{response.body["error"]["code"]}'"
-        when 503
-          raise Error, "Error 503: You have been rate limited for sending more than 20 requests per second. '#{response.body["error"]["code"]}'"
-        when 501
-          raise Error, "Error 501: This resource has not been implemented. '#{response.body["error"]["code"]}'"
+        when 400, 401, 403, 404, 409, 429, 500, 503, 501
+          error = Paddle::ErrorFactory.create(response.body, response.status)
+          raise error if error
         when 204
           return true
         end
 
         if response.body && response.body["error"]
-          raise Error, "Error #{response.body["error"]["code"]} - #{response.body["errors"]["message"]}"
+          error = Paddle::ErrorFactory.create(response.body, response.status)
+          raise error if error
         end
 
         response

--- a/lib/paddle/client.rb
+++ b/lib/paddle/client.rb
@@ -1,52 +1,61 @@
+require "faraday"
+
 module Paddle
   class Client
     class << self
       def connection
-        @connection ||= Faraday.new(Paddle.config.url) do |conn|
+        @connection ||= create_connection
+      end
+
+      def get_request(url, params: {}, headers: {})
+        handle_response(connection.get(url, params, headers))
+      end
+
+      def post_request(url, body: {}, headers: {})
+        handle_response(connection.post(url, body, headers))
+      end
+
+      def patch_request(url, body:, headers: {})
+        handle_response(connection.patch(url, body, headers))
+      end
+
+      def delete_request(url, headers: {})
+        handle_response(connection.delete(url, headers))
+      end
+
+      private
+
+      def create_connection
+        Faraday.new(Paddle.config.url) do |conn|
           conn.request :authorization, :Bearer, Paddle.config.api_key
-
-          conn.headers = {
-            "User-Agent" => "paddle/v#{VERSION} (github.com/deanpcmad/paddle)",
-            "Paddle-Version" => Paddle.config.version.to_s
-          }
-
+          conn.headers = default_headers
           conn.request :json
           conn.response :json
         end
       end
 
-
-      def get_request(url, params: {}, headers: {})
-        handle_response connection.get(url, params, headers)
-      end
-
-      def post_request(url, body: {}, headers: {})
-        handle_response connection.post(url, body, headers)
-      end
-
-      def patch_request(url, body:, headers: {})
-        handle_response connection.patch(url, body, headers)
-      end
-
-      def delete_request(url, headers: {})
-        handle_response connection.delete(url, headers)
+      def default_headers
+        {
+          "User-Agent" => "paddle/v#{VERSION} (github.com/deanpcmad/paddle)",
+          "Paddle-Version" => Paddle.config.version.to_s
+        }
       end
 
       def handle_response(response)
-        case response.status
-        when 400, 401, 403, 404, 409, 429, 500, 503, 501
-          error = Paddle::ErrorFactory.create(response.body, response.status)
-          raise error if error
-        when 204
-          return true
-        end
+        return true if response.status == 204
+        return response unless error?(response)
 
-        if response.body && response.body["error"]
-          error = Paddle::ErrorFactory.create(response.body, response.status)
-          raise error if error
-        end
+        raise_error(response)
+      end
 
-        response
+      def error?(response)
+        [ 400, 401, 403, 404, 409, 429, 500, 501, 503 ].include?(response.status) ||
+          response.body&.key?("error")
+      end
+
+      def raise_error(response)
+        error = Paddle::ErrorFactory.create(response.body, response.status)
+        raise error if error
       end
     end
   end

--- a/lib/paddle/error.rb
+++ b/lib/paddle/error.rb
@@ -11,7 +11,7 @@ module Paddle
     private
 
     def error_message
-      @response.dig("error", "detail") || @response.dig("error", "code")
+      @response.dig(:error, :detail) || @response.dig(:error, :code)
     rescue NoMethodError
       "An unknown error occurred."
     end

--- a/lib/paddle/error.rb
+++ b/lib/paddle/error.rb
@@ -1,4 +1,135 @@
 module Paddle
   class Error < StandardError
+    attr_reader :response
+
+    def initialize(response_body, status_code)
+      @response = response_body
+      @status_code = status_code
+      super(build_message)
+    end
+
+    private
+
+    def error_message
+      @response.dig("error", "detail") || @response.dig("error", "code")
+    rescue NoMethodError
+      "An unknown error occurred."
+    end
+
+    def paddle_error_code
+      @response.deep_symbolize_keys.dig(:error, :code) || nil
+    end
+
+    def build_message
+      if paddle_error_code.nil?
+        return "Error #{@status_code}: #{error_message}"
+      end
+      "Error #{@status_code}: #{error_message} '#{paddle_error_code}'"
+    end
+  end
+
+  class BadRequestError < Error
+    private
+
+    def error_message
+      "Your request was malformed."
+    end
+  end
+
+  class AuthenticationMissingError < Error
+    private
+
+    def error_message
+      "You did not supply valid authentication credentials."
+    end
+  end
+
+  class ForbiddenError < Error
+    private
+
+    def error_message
+      "Error 403: You are not allowed to perform that action."
+    end
+  end
+
+  class EntityNotFoundError < Error
+    private
+
+    def error_message
+      "Error 404: No results were found for your request."
+    end
+  end
+
+  class ConflictError < Error
+    private
+
+    def error_message
+      "Error 409: Your request was a conflict."
+    end
+  end
+
+  class TooManyRequestsError < Error
+    private
+
+    def error_message
+      "Error 429: Your request exceeded the API rate limit."
+    end
+  end
+
+  class InternalError < Error
+    private
+
+    def error_message
+      "Error 500: We were unable to perform the request due to server-side problems."
+    end
+  end
+
+  class ServiceUnavailableError < Error
+    private
+
+    def error_message
+      "Error 503: You have been rate limited for sending more than 20 requests per second."
+    end
+  end
+
+  class NotImplementedError < Error
+    private
+
+    def error_message
+      "Error 501: This resource has not been implemented."
+    end
+  end
+
+  class CustomerAlreadyExistsError < Error
+    private
+
+    def error_message
+      "#{@response.dig(:error, :detail)}"
+    end
+  end
+
+  class ErrorFactory
+    HTTP_ERROR_MAP = {
+      400 => BadRequestError,
+      401 => AuthenticationMissingError,
+      403 => ForbiddenError,
+      404 => EntityNotFoundError,
+      409 => ConflictError,
+      429 => TooManyRequestsError,
+      500 => InternalError,
+      503 => ServiceUnavailableError,
+      501 => NotImplementedError
+    }.freeze
+
+    PADDLE_ERROR_MAP = {
+      "customer_already_exists" => CustomerAlreadyExistsError
+    }.freeze
+
+    def self.create(response_body, status_code)
+      status = status_code
+      error_code = response_body.dig(:error, :code) || nil
+      error_class = PADDLE_ERROR_MAP[error_code] || HTTP_ERROR_MAP[status]
+      error_class.new(response_body, status_code) if error_class
+    end
   end
 end

--- a/lib/paddle/error.rb
+++ b/lib/paddle/error.rb
@@ -48,7 +48,7 @@ module Paddle
     private
 
     def error_message
-      "Error 403: You are not allowed to perform that action."
+      "You are not allowed to perform that action."
     end
   end
 
@@ -56,7 +56,7 @@ module Paddle
     private
 
     def error_message
-      "Error 404: No results were found for your request."
+      "No results were found for your request."
     end
   end
 
@@ -64,7 +64,7 @@ module Paddle
     private
 
     def error_message
-      "Error 409: Your request was a conflict."
+      "Your request was a conflict."
     end
   end
 
@@ -72,7 +72,7 @@ module Paddle
     private
 
     def error_message
-      "Error 429: Your request exceeded the API rate limit."
+      "Your request exceeded the API rate limit."
     end
   end
 
@@ -80,7 +80,7 @@ module Paddle
     private
 
     def error_message
-      "Error 500: We were unable to perform the request due to server-side problems."
+      "We were unable to perform the request due to server-side problems."
     end
   end
 
@@ -88,7 +88,7 @@ module Paddle
     private
 
     def error_message
-      "Error 503: You have been rate limited for sending more than 20 requests per second."
+      "You have been rate limited for sending more than 20 requests per second."
     end
   end
 
@@ -96,7 +96,7 @@ module Paddle
     private
 
     def error_message
-      "Error 501: This resource has not been implemented."
+      "This resource has not been implemented."
     end
   end
 

--- a/lib/paddle/error.rb
+++ b/lib/paddle/error.rb
@@ -14,12 +14,12 @@ module Paddle
     private
 
     def set_paddle_error_values
-      @paddle_error_code = @response_body.deep_symbolize_keys.dig(:error, :code)
-      @paddle_error_message = @response_body.deep_symbolize_keys.dig(:error, :detail)
+      @paddle_error_code = @response_body.dig("error", "code")
+      @paddle_error_message = @response_body.dig("error", "detail")
     end
 
     def error_message
-      @paddle_error_message || @response_body.dig(:error, :code)
+      @paddle_error_message || @response_body.dig("error", "code")
     rescue NoMethodError
       "An unknown error occurred."
     end

--- a/test/paddle/error_test.rb
+++ b/test/paddle/error_test.rb
@@ -7,7 +7,7 @@ class ErrorTest < Minitest::Test
 
   def test_bad_request_error
     error = Paddle::ErrorFactory.create(
-      { 'error': { "code" => 123, "detail" => "Paddle error message" } },
+      { "error" => { "code" => 123, "detail" => "Paddle error message" } },
       400
     )
 
@@ -16,7 +16,7 @@ class ErrorTest < Minitest::Test
 
   def test_authentication_missing_error
     error = Paddle::ErrorFactory.create(
-      { 'error': {} },
+      { "error": {} },
       401
     )
 

--- a/test/paddle/error_test.rb
+++ b/test/paddle/error_test.rb
@@ -23,14 +23,15 @@ class ErrorTest < Minitest::Test
     assert_equal "Error 401: You did not supply valid authentication credentials.", error.message
   end
 
-  def test_customer_already_exists_error
-    error = Paddle::ErrorFactory.create(
-      { "error": { "type": "request_error", "code": "customer_already_exists", "detail": "customer email conflicts with customer of id ctm_01j2c063nh77j5qx5nwhhqkdcg", "documentation_url": "https://developer.paddle.com/v1/errors/customers/customer_already_exists" }, "meta": { "request_id": "f0815456-2b6e-49f5-963d-4772ccfa1630" } },
-      409
-    )
+  def test_paddle_error_code
+    error = Paddle::Error.new({ "error" => { "code" => 123, "detail" => "Paddle error message" } }, 409)
 
-    assert_kind_of Paddle::CustomerAlreadyExistsError, error
+    assert_equal 123, error.paddle_error_code
+  end
 
-    assert_equal "Error 409: customer email conflicts with customer of id ctm_01j2c063nh77j5qx5nwhhqkdcg 'customer_already_exists'", error.message
+  def test_paddle_error_message
+    error = Paddle::Error.new({ "error" => { "code" => 123, "detail" => "Paddle error message" } }, 409)
+
+    assert_equal "Paddle error message", error.paddle_error_message
   end
 end

--- a/test/paddle/error_test.rb
+++ b/test/paddle/error_test.rb
@@ -1,0 +1,36 @@
+class ErrorTest < Minitest::Test
+  def test_generic_error
+    error = Paddle::Error.new({ "error" => { "code" => 123, "detail" => "Paddle error message" } }, 409)
+
+    assert_equal "Error 409: Paddle error message '123'", error.message
+  end
+
+  def test_bad_request_error
+    error = Paddle::ErrorFactory.create(
+      { 'error': { "code" => 123, "detail" => "Paddle error message" } },
+      400
+    )
+
+    assert_equal "Error 400: Your request was malformed. '123'", error.message
+  end
+
+  def test_authentication_missing_error
+    error = Paddle::ErrorFactory.create(
+      { 'error': {} },
+      401
+    )
+
+    assert_equal "Error 401: You did not supply valid authentication credentials.", error.message
+  end
+
+  def test_customer_already_exists_error
+    error = Paddle::ErrorFactory.create(
+      { "error": { "type": "request_error", "code": "customer_already_exists", "detail": "customer email conflicts with customer of id ctm_01j2c063nh77j5qx5nwhhqkdcg", "documentation_url": "https://developer.paddle.com/v1/errors/customers/customer_already_exists" }, "meta": { "request_id": "f0815456-2b6e-49f5-963d-4772ccfa1630" } },
+      409
+    )
+
+    assert_kind_of Paddle::CustomerAlreadyExistsError, error
+
+    assert_equal "Error 409: customer email conflicts with customer of id ctm_01j2c063nh77j5qx5nwhhqkdcg 'customer_already_exists'", error.message
+  end
+end


### PR DESCRIPTION
This change is to allow better handling of errors, and in particular customer_already_exists (https://developer.paddle.com/errors/customers/customer_already_exists)

The need for this originated from https://github.com/pay-rails/pay/pull/1009