### PR TITLE
Add config.connection_options and pass it to Faraday

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,21 @@ Paddle.configure do |config|
 end
 ```
 
+### Connection Options
+
+You can pass [options](https://lostisland.github.io/faraday/#/customization/connection-options) to the underlying [Faraday](https://lostisland.github.io/faraday/) connection using `connection_options`. This is useful for setting timeouts, proxies, or SSL configuration:
+
+```ruby
+Paddle.configure do |config|
+  config.environment = :sandbox
+  config.api_key = ENV["PADDLE_API_KEY"]
+
+  config.connection_options = {
+    request: { timeout: 10, open_timeout: 5 }
+  }
+end
+```
+
 ### Resources
 
 The gem maps as closely as we can to the Paddle API so you can easily convert API examples to gem code.
@@ -84,6 +99,7 @@ When API requests fail, the gem provides detailed error information to help you 
 #### Error Structure
 
 All errors inherit from `Paddle::ErrorGenerator` and include:
+
 - HTTP status code
 - Error code from Paddle
 - Detailed error message
@@ -432,7 +448,6 @@ Paddle::PortalSession.create customer: "ctm_abc123"
 Paddle::PortalSession.create customer: "ctm_abc123", subscription_ids: ["sub_abc123"]
 ```
 
-
 ### Adjustments
 
 ```ruby
@@ -582,7 +597,7 @@ Paddle::Report.create(
 
 ### Webhook Simulation Types
 
-Retrieves a list of Simulation Types - https://developer.paddle.com/api-reference/simulation-types/overview
+Retrieves a list of Simulation Types - <https://developer.paddle.com/api-reference/simulation-types/overview>
 
 ```ruby
 Paddle::SimulationType.list
@@ -647,7 +662,6 @@ Paddle::ClientToken.retrieve id: "ctkn_abc123"
 Paddle::ClientToken.update id: "ctkn_abc123", status: "revoked"
 ```
 
-
 ## Classic API
 
 For accessing the Paddle Classic API
@@ -705,7 +719,7 @@ or [here for sandbox](https://sandbox-vendors.paddle.com/authentication)
 
 ## Contributing
 
-Bug reports and pull requests are welcome on GitHub at https://github.com/deanpcmad/paddle.
+Bug reports and pull requests are welcome on GitHub at <https://github.com/deanpcmad/paddle>.
 
 ## License
 

--- a/lib/paddle/client.rb
+++ b/lib/paddle/client.rb
@@ -26,7 +26,7 @@ module Paddle
       private
 
       def create_connection
-        Faraday.new(Paddle.config.url) do |conn|
+        Faraday.new(Paddle.config.url, Paddle.config.connection_options) do |conn|
           conn.request :authorization, :Bearer, Paddle.config.api_key
           conn.headers = default_headers
           conn.request :json

--- a/lib/paddle/configuration.rb
+++ b/lib/paddle/configuration.rb
@@ -6,10 +6,12 @@ module Paddle
 
     attr_accessor :version
     attr_accessor :api_key
+    attr_accessor :connection_options
 
     def initialize
       @environment ||= :production
       @version ||= 1
+      @connection_options = {}
     end
 
     def environment=(env)

--- a/test/paddle/configuration_test.rb
+++ b/test/paddle/configuration_test.rb
@@ -33,4 +33,40 @@ class ConfigurationTest < Minitest::Test
     Paddle.config.version = 2
     assert_equal 2, Paddle.config.version
   end
+
+  def test_connection_options_defaults_to_empty_hash
+    assert_equal({}, Paddle.config.connection_options)
+  end
+
+  def test_connection_options_passes_timeout_to_faraday
+    Paddle.config.connection_options = { request: { timeout: 10, open_timeout: 5 } }
+    Paddle::Client.instance_variable_set(:@connection, nil)
+
+    conn = Paddle::Client.connection
+    assert_equal 10, conn.options.timeout
+    assert_equal 5, conn.options.open_timeout
+  ensure
+    reset_client_connection
+  end
+
+  def test_connection_options_passes_proxy_to_faraday
+    Paddle.config.connection_options = { proxy: "http://localhost:8080" }
+    Paddle::Client.instance_variable_set(:@connection, nil)
+
+    conn = Paddle::Client.connection
+    assert_equal "http://localhost:8080", conn.proxy.uri.to_s
+  ensure
+    reset_client_connection
+  end
+
+  private
+
+  # Rebuild a clean sandbox connection so VCR-backed tests in other
+  # files always hit sandbox-api.paddle.com regardless of test ordering.
+  def reset_client_connection
+    Paddle.config.connection_options = {}
+    Paddle.config.environment = :sandbox
+    Paddle::Client.instance_variable_set(:@connection, nil)
+    Paddle::Client.connection # force memoization with sandbox URL
+  end
 end


### PR DESCRIPTION
This adds a new config option to make it possible to pass options, such as timeouts, to Faraday.

The code is quite straightforward, but tests got a bit messy with needing to clear the memoized connection in order to allow it to rebuild with new options. Let me know if I missed something obvious there.